### PR TITLE
fix: Eliminar el shortId para evitar colisiones entre los ids generados

### DIFF
--- a/src/components/ColumnContainer.tsx
+++ b/src/components/ColumnContainer.tsx
@@ -20,7 +20,12 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "./ui/alert-dialog";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./ui/tooltip";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "./ui/tooltip";
 
 interface Props {
   column: ColumnType;
@@ -144,7 +149,8 @@ export default function ColumnContainer({
                 Delete column?
               </AlertDialogTitle>
               <AlertDialogDescription className="text-white">
-                This action cannot be undone. The column will be permanently removed.
+                This action cannot be undone. The column will be permanently
+                removed.
               </AlertDialogDescription>
             </AlertDialogHeader>
 

--- a/src/components/KanbanBoard.tsx
+++ b/src/components/KanbanBoard.tsx
@@ -20,7 +20,7 @@ import { v4 as uuidv4 } from "uuid";
 
 // Helpers
 
-const shortId = () => uuidv4().slice(0, 2);
+const Id = () => uuidv4();
 
 export default function KanbanBoard() {
   // State
@@ -30,8 +30,8 @@ export default function KanbanBoard() {
   const [activeColumn, setActiveColumn] = useState<ColumnType | null>(null);
   const [activeTask, setActiveTask] = useState<Task | null>(null);
 
-  const [columnCounter, setColumnCounter] = useState(0);
-  const [taskCounter, setTaskCounter] = useState(0);
+  const [columnCounter, setColumnCounter] = useState<number>(0);
+  const [taskCounter, setTaskCounter] = useState<number>(0);
 
   // Memo
   const columnsId = useMemo(
@@ -49,7 +49,7 @@ export default function KanbanBoard() {
   // Columns CRUD
   const createNewColumn = (): void => {
     const newColumn: ColumnType = {
-      id: shortId(),
+      id: Id(),
       title: `Column ${columnCounter + 1}`,
     };
     setColumns((prev) => [...prev, newColumn]);
@@ -70,7 +70,7 @@ export default function KanbanBoard() {
   // Tasks CRUD
   const createNewTask = (columnId: string | number): void => {
     const newTask: Task = {
-      id: shortId(),
+      id: Id(),
       columnId,
       content: `Task ${taskCounter + 1}`,
     };

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -32,7 +32,6 @@ interface Props {
 }
 
 export default function TaskCard({ task, deleteTask, updateTask }: Props) {
-
   const {
     setNodeRef,
     attributes,


### PR DESCRIPTION
Cambiado el slice de los ids generados para las columnas y las tareas por conflictos de colisiones de ids generados

Issue #6 