### PR TITLE
15 style quitar el tooltip de la card y hacer que se vea el contenido en 3 líneas

### DIFF
--- a/src/components/ColumnContainer.tsx
+++ b/src/components/ColumnContainer.tsx
@@ -159,7 +159,7 @@ export default function ColumnContainer({
             </TooltipProvider>
 
             <AlertDialogContent>
-              <AlertDialogTitle>{`¿ Eliminar Columna ${column.title} ?`}</AlertDialogTitle>
+              <AlertDialogTitle>¿ Eliminar Columna ?</AlertDialogTitle>
               <AlertDialogHeader>
                 <AlertDialogDescription>
                   Esta acción no se puede deshacer. La columna y todas sus

--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -86,7 +86,9 @@ export default function TaskCard({ task, deleteTask, updateTask }: Props) {
       >
         <CardHeader className="p-0 flex">
           <CardTitle className="flex items-center justify-between w-full">
-            <span className="max-w-56 line-clamp-3">{task.content}</span>
+            <span className="max-w-56 line-clamp-3 text-ellipsis">
+              {task.content}
+            </span>
             <div className="flex">
               <DropdownMenu modal={false}>
                 <TooltipProvider>
@@ -167,7 +169,7 @@ export default function TaskCard({ task, deleteTask, updateTask }: Props) {
 
       <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
         <AlertDialogContent>
-          <AlertDialogTitle>{`¿ Eliminar Tarea ${task.content} ?`}</AlertDialogTitle>
+          <AlertDialogTitle>¿ Eliminar Tarea ?</AlertDialogTitle>
           <AlertDialogHeader>
             <AlertDialogDescription>
               Esta acción no se puede deshacer. La tarea será eliminada


### PR DESCRIPTION
## 📌 Descripción

En este pr se ha eliminado el tooltip que tenía la card y se ha definido un máximo de 3 líneas de contenido de la tarea que se pueden visualizar por vez

---

## 🔗 Issue relacionado

Closes #15   

---

## 🧪 Tipo de cambio

Marca lo que aplique:

- [ ] ✨ New feature
- [ ] 🐛 Bug fix
- [x] 🎨 Style / UI
- [ ] 📚 Documentation
- [ ] 🔧 Chore / Refactor

---

## ✅ Checklist

- [x] El código compila y funciona correctamente
- [x] He probado los cambios manualmente
- [x] No rompe funcionalidad existente
- [x] El código sigue las convenciones del proyecto
- [ ] He actualizado la documentación si aplica

---

## 📸 Evidencias

<img width="1919" height="945" alt="1" src="https://github.com/user-attachments/assets/699ca00e-f77b-447c-8c1e-68528cab2f7e" />

