### PR TITLE
55 feature dashboard de analytics por proyecto

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,9 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>kanban-dashboard</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
   </head>
   <body>
     <div id="root"></div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Navigate, Route, Routes } from "react-router"
 import "../tailwind.css"
 import { AuthProvider, AuthGuard, LoginPage, RegisterPage } from "@/features/auth"
 import { ProjectsPage } from "@/features/project"
+import { AnalyticsPage } from "@/features/analytics"
 import AppLayout from "./layouts/AppLayout"
 import KanbanLayout from "./layouts/MainLayout"
 import KanbanBoard from "./features/board/components/KanbanBoard"
@@ -23,6 +24,7 @@ function App() {
               <Route path="/projects" element={<ProjectsPage />} />
               <Route element={<KanbanLayout />}>
                 <Route path="/projects/:id" element={<KanbanBoard />} />
+                <Route path="/projects/:id/analytics" element={<AnalyticsPage />} />
               </Route>
             </Route>
           </Route>

--- a/src/features/analytics/components/ActivityFeed.tsx
+++ b/src/features/analytics/components/ActivityFeed.tsx
@@ -1,0 +1,52 @@
+import { IconArrowRight } from "@tabler/icons-react"
+import { Card, CardContent, CardHeader, CardTitle, ScrollArea, Skeleton } from "@/shared"
+import type { ActivityItem } from "../hooks/useAnalytics"
+
+interface ActivityFeedProps {
+  items: ActivityItem[]
+  loading: boolean
+}
+
+export function ActivityFeed({ items, loading }: ActivityFeedProps) {
+  return (
+    <Card className="flex flex-col">
+      <CardHeader>
+        <CardTitle className="text-base">Actividad reciente</CardTitle>
+        <p className="text-sm text-muted-foreground">Últimos 15 movimientos de tareas</p>
+      </CardHeader>
+      <CardContent className="flex-1 p-0">
+        {loading ? (
+          <div className="px-6 pb-4 flex flex-col gap-3">
+            {Array.from({ length: 5 }).map((_, i) => (
+              <Skeleton key={i} className="h-12 rounded-lg" />
+            ))}
+          </div>
+        ) : items.length === 0 ? (
+          <p className="px-6 pb-4 text-sm text-muted-foreground">
+            Aún no hay movimientos registrados. Mueve tareas entre columnas para ver la actividad.
+          </p>
+        ) : (
+          <ScrollArea className="h-[210px]">
+            <ul className="px-6 pb-4 flex flex-col gap-2">
+              {items.map((item) => (
+                <li key={item.id} className="flex flex-col gap-0.5 py-2 border-b border-border last:border-0">
+                  <p className="text-sm font-medium text-primary truncate">{item.taskContent}</p>
+                  <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                    {item.fromColumnTitle ? (
+                      <>
+                        <span>{item.fromColumnTitle}</span>
+                        <IconArrowRight size={12} />
+                      </>
+                    ) : null}
+                    <span className="text-primary font-medium">{item.toColumnTitle}</span>
+                    <span className="ml-auto shrink-0">{item.movedAtRelative}</span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </ScrollArea>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/features/analytics/components/AnalyticsPage.tsx
+++ b/src/features/analytics/components/AnalyticsPage.tsx
@@ -1,0 +1,34 @@
+import { useParams } from "react-router"
+import { useKanban } from "@/features/board/index"
+import { useAnalytics } from "../hooks/useAnalytics"
+import { StatsCards } from "./StatsCards"
+import { VelocityChart } from "./VelocityChart"
+import { PriorityDistribution } from "./PriorityDistribution"
+import { ActivityFeed } from "./ActivityFeed"
+
+export function AnalyticsPage() {
+  const { id: projectId } = useParams<{ id: string }>()
+  const { columns, tasks } = useKanban()
+  const { velocityData, priorityData, activityItems, stats, loading } = useAnalytics(
+    projectId,
+    columns,
+    tasks,
+  )
+
+  return (
+    <div className="p-6 flex flex-col gap-6 max-w-7xl mx-auto w-full">
+      <StatsCards stats={stats} loading={loading} />
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-2">
+          <VelocityChart data={velocityData} loading={loading} />
+        </div>
+        <div className="lg:col-span-1">
+          <ActivityFeed items={activityItems} loading={loading} />
+        </div>
+      </div>
+
+      <PriorityDistribution data={priorityData} loading={loading} />
+    </div>
+  )
+}

--- a/src/features/analytics/components/PriorityDistribution.tsx
+++ b/src/features/analytics/components/PriorityDistribution.tsx
@@ -1,0 +1,43 @@
+import { Bar, BarChart, CartesianGrid, Cell, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts"
+import { Card, CardContent, CardHeader, CardTitle, Skeleton } from "@/shared"
+import type { PriorityDataPoint } from "../hooks/useAnalytics"
+
+interface PriorityDistributionProps {
+  data: PriorityDataPoint[]
+  loading: boolean
+}
+
+const PRIORITY_COLORS = ["#ef4444", "#f59e0b", "#6b7280"]
+
+export function PriorityDistribution({ data, loading }: PriorityDistributionProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Distribución por prioridad</CardTitle>
+        <p className="text-sm text-muted-foreground">Tareas activas agrupadas por nivel de prioridad</p>
+      </CardHeader>
+      <CardContent>
+        {loading ? (
+          <Skeleton className="h-44 w-full rounded-lg" />
+        ) : (
+          <ResponsiveContainer width="100%" height={180}>
+            <BarChart data={data} margin={{ top: 4, right: 8, left: -20, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+              <XAxis dataKey="prioridad" tick={{ fontSize: 13 }} />
+              <YAxis allowDecimals={false} tick={{ fontSize: 12 }} />
+              <Tooltip
+                contentStyle={{ fontSize: 13 }}
+                formatter={(value) => [value, "Tareas"]}
+              />
+              <Bar dataKey="tareas" radius={[4, 4, 0, 0]}>
+                {data.map((_, i) => (
+                  <Cell key={i} fill={PRIORITY_COLORS[i % PRIORITY_COLORS.length]} />
+                ))}
+              </Bar>
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/features/analytics/components/ProjectNavTabs.tsx
+++ b/src/features/analytics/components/ProjectNavTabs.tsx
@@ -1,0 +1,32 @@
+import { Link, useLocation, useParams } from "react-router"
+import { IconChartBar, IconLayoutKanban } from "@tabler/icons-react"
+
+export function ProjectNavTabs() {
+  const { id } = useParams<{ id: string }>()
+  const location = useLocation()
+  const isAnalytics = location.pathname.endsWith("/analytics")
+
+  const tabs = [
+    { label: "Tablero", path: `/projects/${id}`, icon: IconLayoutKanban, active: !isAnalytics },
+    { label: "Analytics", path: `/projects/${id}/analytics`, icon: IconChartBar, active: isAnalytics },
+  ]
+
+  return (
+    <nav className="flex gap-1 px-6 bg-background border-b border-border">
+      {tabs.map(({ label, path, icon: Icon, active }) => (
+        <Link
+          key={path}
+          to={path}
+          className={`flex items-center gap-2 px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
+            active
+              ? "border-primary text-primary"
+              : "border-transparent text-muted-foreground hover:text-primary hover:border-primary/50"
+          }`}
+        >
+          <Icon size={16} />
+          {label}
+        </Link>
+      ))}
+    </nav>
+  )
+}

--- a/src/features/analytics/components/StatsCards.tsx
+++ b/src/features/analytics/components/StatsCards.tsx
@@ -1,0 +1,42 @@
+import { Card, CardContent, CardHeader, CardTitle, Skeleton } from "@/shared"
+import type { AnalyticsStats } from "../hooks/useAnalytics"
+
+interface StatsCardsProps {
+  stats: AnalyticsStats
+  loading: boolean
+}
+
+const cards = (stats: AnalyticsStats) => [
+  { title: "Total de tareas", value: stats.totalTasks, suffix: "tareas" },
+  { title: "Tareas completadas", value: stats.doneTasks, suffix: "en Done" },
+  { title: "Progreso", value: stats.progressPercent, suffix: "%" },
+  { title: "Movimientos", value: stats.totalMoved, suffix: "en historial" },
+]
+
+export function StatsCards({ stats, loading }: StatsCardsProps) {
+  if (loading) {
+    return (
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className="h-28 rounded-xl" />
+        ))}
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+      {cards(stats).map(({ title, value, suffix }) => (
+        <Card key={title}>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-medium text-muted-foreground">{title}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-3xl font-bold text-primary">{value}</p>
+            <p className="text-xs text-muted-foreground mt-1">{suffix}</p>
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  )
+}

--- a/src/features/analytics/components/VelocityChart.tsx
+++ b/src/features/analytics/components/VelocityChart.tsx
@@ -1,0 +1,37 @@
+import { Bar, BarChart, CartesianGrid, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts"
+import { Card, CardContent, CardHeader, CardTitle, Skeleton } from "@/shared"
+import type { VelocityDataPoint } from "../hooks/useAnalytics"
+
+interface VelocityChartProps {
+  data: VelocityDataPoint[]
+  loading: boolean
+}
+
+export function VelocityChart({ data, loading }: VelocityChartProps) {
+  return (
+    <Card className="flex flex-col">
+      <CardHeader>
+        <CardTitle className="text-base">Velocidad semanal</CardTitle>
+        <p className="text-sm text-muted-foreground">Tareas completadas por semana (últimas 8)</p>
+      </CardHeader>
+      <CardContent className="flex-1">
+        {loading ? (
+          <Skeleton className="h-52 w-full rounded-lg" />
+        ) : (
+          <ResponsiveContainer width="100%" height={210}>
+            <BarChart data={data} margin={{ top: 4, right: 8, left: -20, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" className="stroke-border" />
+              <XAxis dataKey="week" tick={{ fontSize: 12 }} className="text-muted-foreground" />
+              <YAxis allowDecimals={false} tick={{ fontSize: 12 }} className="text-muted-foreground" />
+              <Tooltip
+                contentStyle={{ fontSize: 13 }}
+                formatter={(value) => [value, "Tareas"]}
+              />
+              <Bar dataKey="tareas" fill="hsl(var(--primary))" radius={[4, 4, 0, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/src/features/analytics/hooks/useAnalytics.ts
+++ b/src/features/analytics/hooks/useAnalytics.ts
@@ -1,0 +1,161 @@
+import { useEffect, useState } from "react"
+import { getISOWeek, getISOWeekYear, subWeeks, formatDistanceToNow } from "date-fns"
+import { es } from "date-fns/locale"
+import { supabase } from "@/shared/supabase"
+import type { ColumnType, Task } from "@/features/board/index"
+
+interface TaskHistoryRecord {
+  id: string
+  task_id: string
+  from_column_id: string | null
+  to_column_id: string
+  moved_at: string
+  tasks: { id: string; content: string; project_id: string } | null
+}
+
+export interface VelocityDataPoint {
+  week: string
+  tareas: number
+}
+
+export interface PriorityDataPoint {
+  prioridad: string
+  tareas: number
+}
+
+export interface ActivityItem {
+  id: string
+  taskContent: string
+  fromColumnTitle: string | null
+  toColumnTitle: string
+  movedAt: string
+  movedAtRelative: string
+}
+
+export interface AnalyticsStats {
+  totalTasks: number
+  doneTasks: number
+  progressPercent: number
+  totalMoved: number
+}
+
+export interface UseAnalyticsReturn {
+  velocityData: VelocityDataPoint[]
+  priorityData: PriorityDataPoint[]
+  activityItems: ActivityItem[]
+  stats: AnalyticsStats
+  loading: boolean
+}
+
+const PRIORITY_LABELS: Record<string, string> = {
+  p0: "Urgente",
+  p1: "Normal",
+  p2: "Baja",
+}
+
+const buildVelocityData = (
+  history: TaskHistoryRecord[],
+  doneColumnId: string | undefined,
+): VelocityDataPoint[] => {
+  const now = new Date()
+  const last8Weeks = Array.from({ length: 8 }, (_, i) => {
+    const d = subWeeks(now, 7 - i)
+    const week = getISOWeek(d)
+    const year = getISOWeekYear(d)
+    return {
+      key: `${year}-${String(week).padStart(2, "0")}`,
+      label: `Sem ${week}`,
+    }
+  })
+
+  if (!doneColumnId) return last8Weeks.map(({ label }) => ({ week: label, tareas: 0 }))
+
+  const countByWeek: Record<string, number> = {}
+  history
+    .filter((h) => h.to_column_id === doneColumnId)
+    .forEach((h) => {
+      const d = new Date(h.moved_at)
+      const key = `${getISOWeekYear(d)}-${String(getISOWeek(d)).padStart(2, "0")}`
+      countByWeek[key] = (countByWeek[key] ?? 0) + 1
+    })
+
+  return last8Weeks.map(({ key, label }) => ({ week: label, tareas: countByWeek[key] ?? 0 }))
+}
+
+const buildPriorityData = (tasks: Task[]): PriorityDataPoint[] =>
+  ["p0", "p1", "p2"].map((p) => ({
+    prioridad: PRIORITY_LABELS[p],
+    tareas: tasks.filter((t) => t.priority === p).length,
+  }))
+
+const buildActivityItems = (
+  history: TaskHistoryRecord[],
+  columns: ColumnType[],
+): ActivityItem[] => {
+  const colMap = new Map(columns.map((c) => [c.id, c.title]))
+  return history.slice(0, 15).map((h) => ({
+    id: h.id,
+    taskContent: h.tasks?.content ?? "Tarea eliminada",
+    fromColumnTitle: h.from_column_id ? (colMap.get(h.from_column_id) ?? "Columna eliminada") : null,
+    toColumnTitle: colMap.get(h.to_column_id) ?? "Columna eliminada",
+    movedAt: h.moved_at,
+    movedAtRelative: formatDistanceToNow(new Date(h.moved_at), { addSuffix: true, locale: es }),
+  }))
+}
+
+export const useAnalytics = (
+  projectId: string | undefined,
+  columns: ColumnType[],
+  tasks: Task[],
+): UseAnalyticsReturn => {
+  const [loading, setLoading] = useState(true)
+  const [velocityData, setVelocityData] = useState<VelocityDataPoint[]>([])
+  const [priorityData, setPriorityData] = useState<PriorityDataPoint[]>([])
+  const [activityItems, setActivityItems] = useState<ActivityItem[]>([])
+  const [stats, setStats] = useState<AnalyticsStats>({
+    totalTasks: 0,
+    doneTasks: 0,
+    progressPercent: 0,
+    totalMoved: 0,
+  })
+
+  useEffect(() => {
+    if (!projectId || columns.length === 0) return
+    let cancelled = false
+
+    supabase
+      .from("task_history")
+      .select("id, task_id, from_column_id, to_column_id, moved_at, tasks(id, content, project_id)")
+      .order("moved_at", { ascending: false })
+      .then(({ data }) => {
+        if (cancelled) return
+
+        const history = ((data ?? []) as TaskHistoryRecord[]).filter(
+          (h) => h.tasks?.project_id === projectId,
+        )
+
+        const doneColumnId = columns.find((c) =>
+          c.title.toLowerCase().includes("done"),
+        )?.id
+
+        const doneTasks = doneColumnId
+          ? tasks.filter((t) => t.columnId === doneColumnId).length
+          : 0
+        const totalTasks = tasks.length
+        const progressPercent =
+          totalTasks > 0 ? Math.round((doneTasks / totalTasks) * 100) : 0
+
+        setStats({ totalTasks, doneTasks, progressPercent, totalMoved: history.length })
+        setVelocityData(buildVelocityData(history, doneColumnId))
+        setPriorityData(buildPriorityData(tasks))
+        setActivityItems(buildActivityItems(history, columns))
+        setLoading(false)
+      })
+
+    return () => {
+      cancelled = true
+    }
+  }, [projectId, columns, tasks])
+
+  return { velocityData, priorityData, activityItems, stats, loading }
+}

--- a/src/features/analytics/index.ts
+++ b/src/features/analytics/index.ts
@@ -1,0 +1,3 @@
+export { AnalyticsPage } from "./components/AnalyticsPage"
+export { ProjectNavTabs } from "./components/ProjectNavTabs"
+export { useAnalytics } from "./hooks/useAnalytics"

--- a/src/features/board/components/KanbanBoard.tsx
+++ b/src/features/board/components/KanbanBoard.tsx
@@ -57,20 +57,26 @@ export default function KanbanBoard() {
     setActiveColumn(null)
     setActiveTask(null)
 
-    if (!over || active.id === over.id) {
+    if (!over) {
       dragOriginColumnId.current = null
+      dragTargetColumnId.current = null
       return
     }
 
     // ── Reordenar columnas ────────────────────────────────────────
     if (!wasTask) {
+      if (active.id === over.id) return
       setColumns((prev) => {
         const activeIndex = prev.findIndex((c) => c.id === active.id)
         const overIndex = prev.findIndex((c) => c.id === over.id)
         if (activeIndex === -1 || overIndex === -1) return prev
         const reordered = arrayMove(prev, activeIndex, overIndex)
-        // Persistir nuevas posiciones
-        const updates = reordered.map((col, i) => ({ id: col.id, position: i, project_id: col.project_id, title: col.title }))
+        const updates = reordered.map((col, i) => ({
+          id: col.id,
+          position: i,
+          project_id: col.project_id,
+          title: col.title,
+        }))
         supabase.from("columns").upsert(updates).then(() => {})
         return reordered.map((col, i) => ({ ...col, position: i }))
       })
@@ -78,26 +84,35 @@ export default function KanbanBoard() {
     }
 
     // ── Persistir movimiento de tarea ─────────────────────────────
+    // dragTargetColumnId was set synchronously in onDragOver from dnd-kit's
+    // live ref. This avoids stale closures and the active.id === over.id
+    // early-return that prevented persistence when the cursor was over
+    // the task's own ghost after arrayMove repositioned it in the new column.
     const taskId = String(active.id)
     const originColumnId = dragOriginColumnId.current
-    const newColumnId = dragTargetColumnId.current ?? originColumnId
+    const newColumnId = dragTargetColumnId.current ?? ""
+
     dragOriginColumnId.current = null
     dragTargetColumnId.current = null
 
-    if (!newColumnId) return
+    if (!newColumnId || !originColumnId) return
 
     supabase
       .from("tasks")
       .update({ column_id: newColumnId })
       .eq("id", taskId)
-      .then(() => {})
+      .then(({ error }) => {
+        if (error) console.error("[kanban] task column update failed:", error)
+      })
 
     // Registrar en task_history solo si cambió de columna
-    if (originColumnId && originColumnId !== newColumnId) {
+    if (originColumnId !== newColumnId) {
       supabase
         .from("task_history")
         .insert({ task_id: taskId, from_column_id: originColumnId, to_column_id: newColumnId })
-        .then(() => {})
+        .then(({ error }) => {
+          if (error) console.error("[kanban] task_history insert failed:", error)
+        })
     }
   }
 
@@ -111,6 +126,16 @@ export default function KanbanBoard() {
 
     if (!isActiveTask) return
 
+    // Track destination synchronously from dnd-kit's live ref before setTasks runs.
+    // We read the OVER element's data (never the active task's data) so the value
+    // is always stable — only the active task's columnId changes via setTasks.
+    if (isOverTask) {
+      const overTask = over.data.current?.task as { columnId: string } | undefined
+      if (overTask?.columnId) dragTargetColumnId.current = overTask.columnId
+    } else if (isOverColumn) {
+      dragTargetColumnId.current = String(over.id)
+    }
+
     setTasks((prev) => {
       const activeIndex = prev.findIndex((t) => t.id === active.id)
       if (activeIndex === -1) return prev
@@ -119,17 +144,13 @@ export default function KanbanBoard() {
         const overIndex = prev.findIndex((t) => t.id === over.id)
         if (overIndex === -1) return prev
         const updated = [...prev]
-        const targetColumnId = updated[overIndex].columnId
-        updated[activeIndex] = { ...updated[activeIndex], columnId: targetColumnId }
-        dragTargetColumnId.current = targetColumnId
+        updated[activeIndex] = { ...updated[activeIndex], columnId: updated[overIndex].columnId }
         return arrayMove(updated, activeIndex, overIndex)
       }
 
       if (isOverColumn) {
-        const targetColumnId = String(over.id)
         const updated = [...prev]
-        updated[activeIndex] = { ...updated[activeIndex], columnId: targetColumnId }
-        dragTargetColumnId.current = targetColumnId
+        updated[activeIndex] = { ...updated[activeIndex], columnId: String(over.id) }
         return updated
       }
 

--- a/src/features/board/components/KanbanBoard.tsx
+++ b/src/features/board/components/KanbanBoard.tsx
@@ -197,7 +197,7 @@ export default function KanbanBoard() {
   }
 
   return (
-    <div className="min-w-max p-4">
+    <div className="min-w-max pt-6 px-4 pb-4">
       <DndContext sensors={sensors} onDragStart={onDragStart} onDragEnd={onDragEnd} onDragOver={onDragOver}>
         <div className="m-auto flex gap-2">
           <SortableContext items={columnsId}>

--- a/src/features/board/components/KanbanBoard.tsx
+++ b/src/features/board/components/KanbanBoard.tsx
@@ -97,13 +97,51 @@ export default function KanbanBoard() {
 
     if (!newColumnId || !originColumnId) return
 
-    supabase
-      .from("tasks")
-      .update({ column_id: newColumnId })
-      .eq("id", taskId)
-      .then(({ error }) => {
-        if (error) console.error("[kanban] task column update failed:", error)
-      })
+    // Persistir posiciones (y column_id) para las columnas afectadas.
+    // El functional updater recibe el estado YA actualizado por onDragOver
+    // (columnId correcto + orden por arrayMove), así que prev es la fuente
+    // de verdad del orden final — sin dependencia de closures estables.
+    setTasks((prev) => {
+      const tasksInNewColumn = prev.filter((t) => t.columnId === newColumnId)
+      supabase
+        .from("tasks")
+        .upsert(
+          tasksInNewColumn.map((t, i) => ({
+            id: t.id,
+            position: i,
+            column_id: t.columnId,
+            project_id: t.project_id,
+            content: t.content,
+            priority: t.priority,
+            size: t.size,
+          })),
+        )
+        .then(({ error }) => {
+          if (error) console.error("[kanban] task positions upsert failed:", error)
+        })
+
+      if (originColumnId !== newColumnId) {
+        const tasksInOriginColumn = prev.filter((t) => t.columnId === originColumnId)
+        supabase
+          .from("tasks")
+          .upsert(
+            tasksInOriginColumn.map((t, i) => ({
+              id: t.id,
+              position: i,
+              column_id: t.columnId,
+              project_id: t.project_id,
+              content: t.content,
+              priority: t.priority,
+              size: t.size,
+            })),
+          )
+          .then(({ error }) => {
+            if (error) console.error("[kanban] origin column positions upsert failed:", error)
+          })
+      }
+
+      return prev
+    })
 
     // Registrar en task_history solo si cambió de columna
     if (originColumnId !== newColumnId) {

--- a/src/features/project/components/ProjectSidebarContent.tsx
+++ b/src/features/project/components/ProjectSidebarContent.tsx
@@ -1,5 +1,5 @@
-import { IconLayoutKanban, IconLogout } from "@tabler/icons-react"
-import { Link, useNavigate, useParams } from "react-router"
+import { IconChartBar, IconLayoutKanban, IconLogout } from "@tabler/icons-react"
+import { Link, useLocation, useNavigate, useParams } from "react-router"
 import {
   SidebarContent,
   SidebarFooter,
@@ -14,10 +14,16 @@ import { Button } from "@/shared"
 import { supabase } from "@/shared/supabase"
 import { useProjectsContext } from "../context/projectsCtx"
 
+const PROJECT_VIEWS = [
+  { label: "Tablero", icon: IconLayoutKanban, path: (id: string) => `/projects/${id}` },
+  { label: "Analytics", icon: IconChartBar, path: (id: string) => `/projects/${id}/analytics` },
+]
+
 export function ProjectSidebarContent() {
   const { open } = useSidebar()
   const { projects } = useProjectsContext()
   const { id: activeId } = useParams()
+  const location = useLocation()
   const navigate = useNavigate()
 
   const handleLogout = async () => {
@@ -50,30 +56,52 @@ export function ProjectSidebarContent() {
           {open && <SidebarGroupLabel>Proyectos</SidebarGroupLabel>}
           <SidebarGroupContent>
             <SidebarMenu>
-              {projects.map((project) => (
-                <SidebarMenuItem key={project.id}>
-                  <Link
-                    to={`/projects/${project.id}`}
-                    className={`flex items-center gap-3 px-3 py-2 rounded-md transition-colors ${
-                      activeId === project.id
-                        ? "bg-muted text-primary font-medium"
-                        : "hover:bg-muted text-muted-foreground hover:text-primary"
-                    } ${open ? "justify-start" : "justify-center"}`}
-                  >
-                    <span
-                      className="h-2.5 w-2.5 rounded-full shrink-0"
-                      style={{ backgroundColor: project.color }}
-                    />
-                    {open && (
-                      <span className="truncate text-sm">{project.name}</span>
+              {projects.map((project) => {
+                const isActive = activeId === project.id
+                return (
+                  <SidebarMenuItem key={project.id}>
+                    <Link
+                      to={`/projects/${project.id}`}
+                      className={`flex items-center gap-3 px-3 py-2 rounded-md transition-colors ${
+                        isActive
+                          ? "bg-muted text-primary font-medium"
+                          : "hover:bg-muted text-muted-foreground hover:text-primary"
+                      } ${open ? "justify-start" : "justify-center"}`}
+                    >
+                      <span
+                        className="h-2.5 w-2.5 rounded-full shrink-0"
+                        style={{ backgroundColor: project.color }}
+                      />
+                      {open && <span className="truncate text-sm">{project.name}</span>}
+                    </Link>
+
+                    {isActive && open && (
+                      <div className="mt-0.5 flex flex-col gap-0.5">
+                        {PROJECT_VIEWS.map(({ label, icon: Icon, path }) => {
+                          const href = path(project.id)
+                          const isView = location.pathname === href
+                          return (
+                            <Link
+                              key={label}
+                              to={href}
+                              className={`flex items-center gap-2 pl-8 pr-3 py-1.5 rounded-md text-sm transition-colors ${
+                                isView
+                                  ? "text-primary font-medium bg-primary/8"
+                                  : "text-muted-foreground hover:text-primary hover:bg-muted"
+                              }`}
+                            >
+                              <Icon size={14} />
+                              {label}
+                            </Link>
+                          )
+                        })}
+                      </div>
                     )}
-                  </Link>
-                </SidebarMenuItem>
-              ))}
+                  </SidebarMenuItem>
+                )
+              })}
               {projects.length === 0 && open && (
-                <p className="px-3 text-xs text-muted-foreground">
-                  Sin proyectos aún
-                </p>
+                <p className="px-3 text-xs text-muted-foreground">Sin proyectos aún</p>
               )}
             </SidebarMenu>
           </SidebarGroupContent>

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react"
-import { Outlet, useParams } from "react-router"
+import { Outlet, useLocation, useParams } from "react-router"
 import {
   Header,
   SearchContext,
@@ -17,6 +17,8 @@ function KanbanContent() {
   const [searchValue, setSearchValue] = useState<string>("")
   const { id } = useParams()
   const { projects } = useProjectsContext()
+  const location = useLocation()
+  const isAnalytics = location.pathname.endsWith("/analytics")
   const projectName = projects.find((p) => p.id === id)?.name
 
   const filteredTasks = tasks.filter((task) => {
@@ -27,14 +29,21 @@ function KanbanContent() {
 
   return (
     <>
-      <Header searchValue={searchValue} onSearchChange={setSearchValue} projectName={projectName} />
+      <Header
+        projectName={projectName}
+        {...(!isAnalytics && { searchValue, onSearchChange: setSearchValue })}
+      />
       <main
-        ref={scrollContainerRef}
-        className={`flex-1 overflow-x-auto overflow-y-hidden flex items-center bg-muted ${
-          state === "collapsed" ? "pl-4" : ""
-        } ${!loading && columns.length === 0 ? "justify-center" : ""}`}
+        ref={!isAnalytics ? scrollContainerRef : undefined}
+        className={
+          isAnalytics
+            ? `flex-1 overflow-y-auto overflow-x-hidden bg-muted ${state === "collapsed" ? "pl-4" : ""}`
+            : `flex-1 overflow-x-auto overflow-y-hidden flex items-center bg-muted ${state === "collapsed" ? "pl-4" : ""} ${!loading && columns.length === 0 ? "justify-center" : ""}`
+        }
       >
-        {loading ? (
+        {isAnalytics ? (
+          <Outlet />
+        ) : loading ? (
           <div className="flex gap-3 p-4">
             {Array.from({ length: 3 }).map((_, i) => (
               <Skeleton key={i} className="w-[350px] h-[620px] rounded-lg shrink-0" />

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -38,13 +38,13 @@ function KanbanContent() {
         className={
           isAnalytics
             ? `flex-1 overflow-y-auto overflow-x-hidden bg-muted ${state === "collapsed" ? "pl-4" : ""}`
-            : `flex-1 overflow-x-auto overflow-y-hidden flex items-center bg-muted ${state === "collapsed" ? "pl-4" : ""} ${!loading && columns.length === 0 ? "justify-center" : ""}`
+            : `flex-1 overflow-x-auto overflow-y-hidden flex bg-muted ${state === "collapsed" ? "pl-4" : ""}`
         }
       >
         {isAnalytics ? (
           <Outlet />
         ) : loading ? (
-          <div className="flex gap-3 p-4">
+          <div className="flex gap-3 pt-6 px-4 pb-4">
             {Array.from({ length: 3 }).map((_, i) => (
               <Skeleton key={i} className="w-[350px] h-[620px] rounded-lg shrink-0" />
             ))}
@@ -64,7 +64,7 @@ function KanbanContent() {
             )}
           </SearchContext.Provider>
         ) : (
-          <div className="flex flex-col items-center justify-center">
+          <div className="w-full h-full flex flex-col items-center justify-center">
             <img src={noDataSvg} alt="No data" className="size-64 mb-4" />
             <p className="text-primary text-lg">
               No hay columnas creadas. Pulse en el botón{" "}

--- a/src/layouts/MainLayout.tsx
+++ b/src/layouts/MainLayout.tsx
@@ -2,6 +2,7 @@ import { useState } from "react"
 import { Outlet, useLocation, useParams } from "react-router"
 import {
   Header,
+  ScrollArea,
   SearchContext,
   Skeleton,
   useSidebar,
@@ -37,12 +38,14 @@ function KanbanContent() {
         ref={!isAnalytics ? scrollContainerRef : undefined}
         className={
           isAnalytics
-            ? `flex-1 overflow-y-auto overflow-x-hidden bg-muted ${state === "collapsed" ? "pl-4" : ""}`
+            ? `flex-1 overflow-hidden bg-muted ${state === "collapsed" ? "pl-4" : ""}`
             : `flex-1 overflow-x-auto overflow-y-hidden flex bg-muted ${state === "collapsed" ? "pl-4" : ""}`
         }
       >
         {isAnalytics ? (
-          <Outlet />
+          <ScrollArea className="h-full">
+            <Outlet />
+          </ScrollArea>
         ) : loading ? (
           <div className="flex gap-3 pt-6 px-4 pb-4">
             {Array.from({ length: 3 }).map((_, i) => (

--- a/src/shared/components/Header.tsx
+++ b/src/shared/components/Header.tsx
@@ -30,7 +30,7 @@ export function Header({ searchValue, onSearchChange, projectName }: HeaderProps
 
   return (
     <>
-      <header className="flex items-center justify-between gap-4 border-b px-6 py-4 bg-background border-b-transparent shadow-md">
+      <header className="h-16 shrink-0 flex items-center justify-between gap-4 border-b px-6 bg-background border-b-transparent shadow-md">
         <div className="flex items-center gap-4">
           <SidebarTrigger className="text-primary" />
           <h1 className="text-xl font-semibold text-primary flex items-center gap-2">

--- a/src/shared/components/Header.tsx
+++ b/src/shared/components/Header.tsx
@@ -13,8 +13,8 @@ import { useKanban } from "@/features/board/index";
 import { CreateColumnSheet } from "@/features/column/index";
 
 interface HeaderProps {
-  searchValue: string;
-  onSearchChange: (value: string) => void;
+  searchValue?: string;
+  onSearchChange?: (value: string) => void;
   projectName?: string;
 }
 
@@ -43,41 +43,45 @@ export function Header({ searchValue, onSearchChange, projectName }: HeaderProps
             )}
           </h1>
         </div>
-        <div className="flex items-center gap-4">
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <div>
-                  <SearchInput
-                    value={searchValue}
-                    onChange={onSearchChange}
-                    disabled={tasks.length === 0}
-                  />
-                </div>
-              </TooltipTrigger>
-              {tasks.length === 0 && (
-                <TooltipContent>
-                  Crea una tarea para empezar a filtrar
-                </TooltipContent>
-              )}
-            </Tooltip>
-          </TooltipProvider>
-          <Button
-            onClick={() => setCreateColumnDialogOpen(true)}
-            className="text-black group border-dashed border-2 hover:border-primary hover:bg-primary/5 hover:text-primary transition-all"
-            variant="outline"
-            disabled={columns.length >= 6}
-          >
-            <IconPlus className="h-4 w-4 mr-2 transition-transform duration-300 group-hover:rotate-90" />
-            Agregar Columna
-          </Button>
-        </div>
+        {onSearchChange && (
+          <div className="flex items-center gap-4">
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <div>
+                    <SearchInput
+                      value={searchValue ?? ""}
+                      onChange={onSearchChange}
+                      disabled={tasks.length === 0}
+                    />
+                  </div>
+                </TooltipTrigger>
+                {tasks.length === 0 && (
+                  <TooltipContent>
+                    Crea una tarea para empezar a filtrar
+                  </TooltipContent>
+                )}
+              </Tooltip>
+            </TooltipProvider>
+            <Button
+              onClick={() => setCreateColumnDialogOpen(true)}
+              className="text-black group border-dashed border-2 hover:border-primary hover:bg-primary/5 hover:text-primary transition-all"
+              variant="outline"
+              disabled={columns.length >= 6}
+            >
+              <IconPlus className="h-4 w-4 mr-2 transition-transform duration-300 group-hover:rotate-90" />
+              Agregar Columna
+            </Button>
+          </div>
+        )}
       </header>
-      <CreateColumnSheet
-        open={createColumnDialogOpen}
-        onOpenChange={setCreateColumnDialogOpen}
-        onSave={handleCreateColumn}
-      />
+      {onSearchChange && (
+        <CreateColumnSheet
+          open={createColumnDialogOpen}
+          onOpenChange={setCreateColumnDialogOpen}
+          onSave={handleCreateColumn}
+        />
+      )}
     </>
   );
 }

--- a/tailwind.css
+++ b/tailwind.css
@@ -21,26 +21,26 @@ html, body, #root {
     --orange: hsl(32 97.7% 62.4%);
     --yellow: hsl(50 97.8% 63.5%);
 
-    --background: hsl(201.3 100% 98%);
-    --foreground: hsl(201.3 5% 10%);
-    --card: hsl(201.3 50% 98%);
-    --card-foreground: hsl(201.3 5% 15%);
+    --background: hsl(0 0% 100%);
+    --foreground: hsl(240 4% 10%);
+    --card: hsl(0 0% 100%);
+    --card-foreground: hsl(240 4% 15%);
     --popover: hsl(0 0% 100%);
-    --popover-foreground: hsl(222.2 84% 4.9%);
-    --primary: hsl(201.3 96.3% 32.2%);
+    --popover-foreground: hsl(240 4% 10%);
+    --primary: hsl(224 71% 40%);
     --primary-foreground: hsl(0 0% 100%);
-    --secondary: hsl(201.3 30% 90%);
-    --secondary-foreground: hsl(0 0% 0%);
-    --muted: hsl(210 40% 96.1%);
-    --muted-foreground: hsl(215.4 16.3% 46.9%);
-    --accent: hsl(210 40% 96.1%);
-    --accent-foreground: hsl(222.2 47.4% 11.2%);
-    --destructive: hsl(0 100% 50%);
-    --destructive-foreground: hsl(201.3 5% 98%);
-    --border: hsl(201.3 30% 82%);
-    --input: hsl(201.3 30% 50%);
-    --ring: hsl(201.3 96.3% 32.2%);
-    --row-selected: hsl(201, 72%, 80%);
+    --secondary: hsl(240 5% 92%);
+    --secondary-foreground: hsl(240 4% 10%);
+    --muted: hsl(240 5% 96%);
+    --muted-foreground: hsl(240 4% 46%);
+    --accent: hsl(240 5% 96%);
+    --accent-foreground: hsl(240 4% 10%);
+    --destructive: hsl(0 84% 60%);
+    --destructive-foreground: hsl(0 0% 100%);
+    --border: hsl(240 5% 90%);
+    --input: hsl(240 5% 65%);
+    --ring: hsl(224 71% 40%);
+    --row-selected: hsl(224 71% 90%);
     --radius: 0.5rem;
 
     --vis-tooltip-background-color: none !important;
@@ -137,6 +137,7 @@ html, body, #root {
 
     body {
         @apply bg-background text-foreground;
+        font-family: 'Inter', system-ui, sans-serif;
     }
 
     @media print {


### PR DESCRIPTION
## 📌 Descripción

En este pr se añade un dashboard de analytics por proyecto con métricas derivadas de `task_history` (throughput semanal, distribución por prioridad, actividad reciente y stats generales). Incluye sub-navegación Tablero/Analytics en la sidebar, rediseño visual con Inter + paleta azul profundo, y corrección de dos bugs de persistencia en el drag & drop del tablero.

---

## 🔗 Issue relacionado

Closes #55 

---

## 🧪 Tipo de cambio

- [x] ✨ New feature
- [x] 🐛 Bug fix
- [x] 🎨 Style / UI

---

## ✅ Checklist

- [x] El código compila y funciona correctamente
- [x] He probado los cambios manualmente
- [x] No rompe funcionalidad existente
- [x] El código sigue las convenciones del proyecto
- [ ] He actualizado la documentación si aplica

---