### PR TITLE
feat: tema claro/oscuro y gestión completa del proyecto

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,15 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>kanban-dashboard</title>
+    <script>
+      (function () {
+        const saved = localStorage.getItem("theme");
+        const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+        if (saved === "dark" || (!saved && prefersDark)) {
+          document.documentElement.classList.add("dark");
+        }
+      })();
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />

--- a/src/features/project/components/ProjectSettingsPage.tsx
+++ b/src/features/project/components/ProjectSettingsPage.tsx
@@ -1,11 +1,13 @@
 import { useState } from "react"
-import { useParams } from "react-router"
+import { useParams, useNavigate } from "react-router"
 import {
   IconCheck,
   IconCopy,
   IconLink,
   IconMail,
   IconSettings,
+  IconShieldX,
+  IconTrash,
   IconUserMinus,
   IconUserPlus,
   IconUsers,
@@ -30,6 +32,7 @@ import {
 } from "@/shared/index"
 import { useKanban } from "@/features/board/index"
 import { useProjectMembers } from "../hooks/useProjectMembers"
+import { useProjectsContext } from "../context/projectsCtx"
 import type { MemberRole } from "@/shared/supabase"
 
 const AVATAR_COLORS = [
@@ -70,8 +73,10 @@ const RoleBadge = ({ role }: { role: MemberRole }) => (
 
 export function ProjectSettingsPage() {
   const { id: projectId } = useParams<{ id: string }>()
+  const navigate = useNavigate()
   const { userRole } = useKanban()
   const isOwner = userRole === "owner"
+  const { deleteProject } = useProjectsContext()
 
   const { members, invitations, loading, inviteMember, cancelInvitation, removeMember } =
     useProjectMembers(projectId ?? "")
@@ -80,6 +85,13 @@ export function ProjectSettingsPage() {
   const [inviting, setInviting] = useState(false)
   const [copiedToken, setCopiedToken] = useState<string | null>(null)
   const [inviteLink, setInviteLink] = useState<string | null>(null)
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
+
+  const handleDeleteProject = async () => {
+    if (!projectId) return
+    await deleteProject(projectId)
+    navigate("/projects")
+  }
 
   const handleInvite = async () => {
     if (!email.trim()) return
@@ -324,6 +336,58 @@ export function ProjectSettingsPage() {
           )}
         </>
       )}
+
+      {/* ── Zona de peligro (solo owner) ── */}
+      {isOwner && (
+        <Card className="border-destructive/40">
+          <CardHeader className="pb-3">
+            <div className="flex items-center gap-2">
+              <IconShieldX size={16} className="text-destructive" />
+              <span className="font-semibold text-sm text-destructive">Zona de peligro</span>
+            </div>
+          </CardHeader>
+          <CardContent className="pt-0">
+            <div className="flex items-center justify-between gap-4">
+              <div>
+                <p className="text-sm font-medium">Eliminar este proyecto</p>
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  Se eliminarán todas las columnas, tareas, miembros e invitaciones. Esta acción es permanente.
+                </p>
+              </div>
+              <Button
+                variant="destructive"
+                size="sm"
+                className="shrink-0"
+                onClick={() => setDeleteDialogOpen(true)}
+              >
+                <IconTrash size={14} />
+                Eliminar
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>¿Eliminar proyecto?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Esta acción no se puede deshacer. Se eliminarán permanentemente todas las columnas,
+              tareas, miembros e invitaciones del proyecto.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+              onClick={handleDeleteProject}
+            >
+              Eliminar proyecto
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   )
 }

--- a/src/features/project/components/ProjectSettingsPage.tsx
+++ b/src/features/project/components/ProjectSettingsPage.tsx
@@ -5,6 +5,7 @@ import {
   IconCopy,
   IconLink,
   IconMail,
+  IconPencil,
   IconSettings,
   IconShieldX,
   IconTrash,
@@ -76,7 +77,9 @@ export function ProjectSettingsPage() {
   const navigate = useNavigate()
   const { userRole } = useKanban()
   const isOwner = userRole === "owner"
-  const { deleteProject } = useProjectsContext()
+  const { projects, deleteProject, renameProject } = useProjectsContext()
+
+  const currentProject = projects.find((p) => p.id === projectId)
 
   const { members, invitations, loading, inviteMember, cancelInvitation, removeMember } =
     useProjectMembers(projectId ?? "")
@@ -86,12 +89,9 @@ export function ProjectSettingsPage() {
   const [copiedToken, setCopiedToken] = useState<string | null>(null)
   const [inviteLink, setInviteLink] = useState<string | null>(null)
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false)
-
-  const handleDeleteProject = async () => {
-    if (!projectId) return
-    await deleteProject(projectId)
-    navigate("/projects")
-  }
+  const [newName, setNewName] = useState(currentProject?.name ?? "")
+  const [renaming, setRenaming] = useState(false)
+  const [renamed, setRenamed] = useState(false)
 
   const handleInvite = async () => {
     if (!email.trim()) return
@@ -110,8 +110,23 @@ export function ProjectSettingsPage() {
     setTimeout(() => setCopiedToken(null), 2000)
   }
 
+  const handleDeleteProject = async () => {
+    if (!projectId) return
+    await deleteProject(projectId)
+    navigate("/projects")
+  }
+
+  const handleRename = async () => {
+    if (!projectId || !newName.trim() || newName.trim() === currentProject?.name) return
+    setRenaming(true)
+    await renameProject(projectId, newName.trim())
+    setRenaming(false)
+    setRenamed(true)
+    setTimeout(() => setRenamed(false), 2000)
+  }
+
   return (
-    <div className="p-6 flex flex-col gap-6 max-w-2xl w-full">
+    <div className="p-6 flex flex-col gap-6 max-w-4xl w-full">
       {/* ── Header ── */}
       <div className="flex items-center gap-3 pb-2">
         <div className="p-2 rounded-lg bg-primary/10">
@@ -123,153 +138,200 @@ export function ProjectSettingsPage() {
         </div>
       </div>
 
-      {/* ── Miembros actuales ── */}
-      <Card>
-        <CardHeader className="pb-3">
-          <div className="flex items-center gap-2">
-            <IconUsers size={16} className="text-muted-foreground" />
-            <span className="font-semibold text-sm">
-              Miembros{" "}
-              <span className="text-muted-foreground font-normal">({members.length})</span>
-            </span>
-          </div>
-        </CardHeader>
-        <CardContent className="pt-0">
-          {loading ? (
-            <div className="flex flex-col gap-2">
-              {[1, 2].map((i) => (
-                <div key={i} className="h-16 rounded-lg bg-muted animate-pulse" />
-              ))}
-            </div>
-          ) : members.length === 0 ? (
-            <p className="text-sm text-muted-foreground py-4 text-center">Sin miembros aún.</p>
-          ) : (
-            <div className="flex flex-col divide-y divide-border">
-              {members.map((m) => (
-                <div key={m.id} className="flex items-center gap-3 py-3 first:pt-0 last:pb-0">
-                  <div
-                    className={`h-10 w-10 rounded-full text-sm flex items-center justify-center font-bold shrink-0 ${getAvatarColor(m.user_id)}`}
-                  >
-                    {getInitials(m.profiles?.full_name)}
-                  </div>
-                  <div className="flex-1 min-w-0">
-                    <div className="flex items-center gap-2 flex-wrap">
-                      <p className="text-sm font-medium leading-tight">
-                        {m.profiles?.full_name ?? "Sin nombre"}
-                      </p>
-                      <RoleBadge role={m.role} />
-                    </div>
-                    {m.profiles?.email && (
-                      <p className="text-xs text-muted-foreground mt-0.5 flex items-center gap-1">
-                        <IconMail size={11} />
-                        {m.profiles.email}
-                      </p>
-                    )}
-                  </div>
-                  {isOwner && m.role !== "owner" && (
-                    <AlertDialog>
-                      <AlertDialogTrigger asChild>
-                        <Button
-                          variant="ghost"
-                          size="icon-sm"
-                          className="hover:text-destructive hover:bg-destructive/10 shrink-0"
-                          title="Eliminar miembro"
-                        >
-                          <IconUserMinus size={16} />
-                        </Button>
-                      </AlertDialogTrigger>
-                      <AlertDialogContent>
-                        <AlertDialogHeader>
-                          <AlertDialogTitle>¿Eliminar miembro?</AlertDialogTitle>
-                          <AlertDialogDescription>
-                            <strong>{m.profiles?.full_name ?? m.profiles?.email ?? "Este miembro"}</strong>{" "}
-                            perderá el acceso al proyecto. Esta acción no se puede deshacer.
-                          </AlertDialogDescription>
-                        </AlertDialogHeader>
-                        <AlertDialogFooter>
-                          <AlertDialogCancel>Cancelar</AlertDialogCancel>
-                          <AlertDialogAction
-                            className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
-                            onClick={() => removeMember(m.id)}
-                          >
-                            Eliminar
-                          </AlertDialogAction>
-                        </AlertDialogFooter>
-                      </AlertDialogContent>
-                    </AlertDialog>
-                  )}
-                </div>
-              ))}
-            </div>
-          )}
-        </CardContent>
-      </Card>
+      {/* ── Grid 2×2 ── */}
+      <div className="grid grid-cols-2 gap-6">
 
-      {/* ── Invitar miembro (solo owner) ── */}
-      {isOwner && (
-        <>
+        {/* ── Col izquierda: Miembros + Renombrar ── */}
+        <div className="flex flex-col gap-6">
+
+          {/* Miembros actuales */}
           <Card>
             <CardHeader className="pb-3">
               <div className="flex items-center gap-2">
-                <IconUserPlus size={16} className="text-muted-foreground" />
-                <span className="font-semibold text-sm">Invitar miembro</span>
+                <IconUsers size={16} className="text-muted-foreground" />
+                <span className="font-semibold text-sm">
+                  Miembros{" "}
+                  <span className="text-muted-foreground font-normal">({members.length})</span>
+                </span>
               </div>
             </CardHeader>
-            <CardContent className="pt-0 flex flex-col gap-3">
-              <div className="flex gap-2">
-                <div className="flex-1">
-                  <Label htmlFor="invite-email" className="sr-only">
-                    Email del invitado
-                  </Label>
-                  <Input
-                    id="invite-email"
-                    type="email"
-                    placeholder="correo@ejemplo.com"
-                    value={email}
-                    onChange={(e) => setEmail(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") handleInvite()
-                    }}
-                  />
+            <CardContent className="pt-0">
+              {loading ? (
+                <div className="flex flex-col gap-2">
+                  {[1, 2].map((i) => (
+                    <div key={i} className="h-16 rounded-lg bg-muted animate-pulse" />
+                  ))}
                 </div>
-                <Button onClick={handleInvite} disabled={inviting || !email.trim()}>
-                  {inviting ? "Enviando…" : "Invitar"}
-                </Button>
-              </div>
-
-              {inviteLink && (
-                <>
-                  <Separator />
-                  <div className="flex flex-col gap-2">
-                    <p className="text-xs text-muted-foreground flex items-center gap-1.5">
-                      <IconLink size={12} />
-                      Comparte este enlace con el invitado (válido 7 días)
-                    </p>
-                    <Button
-                      variant="outline"
-                      className="w-full gap-2 font-normal"
-                      onClick={() => handleCopy(inviteLink)}
-                    >
-                      {copiedToken === inviteLink ? (
-                        <>
-                          <IconCheck size={15} className="text-emerald-500 shrink-0" />
-                          <span className="text-emerald-600">¡Enlace copiado!</span>
-                        </>
-                      ) : (
-                        <>
-                          <IconCopy size={15} className="shrink-0" />
-                          <span className="truncate text-left">{inviteLink}</span>
-                        </>
+              ) : members.length === 0 ? (
+                <p className="text-sm text-muted-foreground py-4 text-center">Sin miembros aún.</p>
+              ) : (
+                <div className="flex flex-col divide-y divide-border">
+                  {members.map((m) => (
+                    <div key={m.id} className="flex items-center gap-3 py-3 first:pt-0 last:pb-0">
+                      <div
+                        className={`h-10 w-10 rounded-full text-sm flex items-center justify-center font-bold shrink-0 ${getAvatarColor(m.user_id)}`}
+                      >
+                        {getInitials(m.profiles?.full_name)}
+                      </div>
+                      <div className="flex-1 min-w-0">
+                        <div className="flex items-center gap-2 flex-wrap">
+                          <p className="text-sm font-medium leading-tight">
+                            {m.profiles?.full_name ?? "Sin nombre"}
+                          </p>
+                          <RoleBadge role={m.role} />
+                        </div>
+                        {m.profiles?.email && (
+                          <p className="text-xs text-muted-foreground mt-0.5 flex items-center gap-1">
+                            <IconMail size={11} />
+                            {m.profiles.email}
+                          </p>
+                        )}
+                      </div>
+                      {isOwner && m.role !== "owner" && (
+                        <AlertDialog>
+                          <AlertDialogTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon-sm"
+                              className="hover:text-destructive hover:bg-destructive/10 shrink-0"
+                              title="Eliminar miembro"
+                            >
+                              <IconUserMinus size={16} />
+                            </Button>
+                          </AlertDialogTrigger>
+                          <AlertDialogContent>
+                            <AlertDialogHeader>
+                              <AlertDialogTitle>¿Eliminar miembro?</AlertDialogTitle>
+                              <AlertDialogDescription>
+                                <strong>{m.profiles?.full_name ?? m.profiles?.email ?? "Este miembro"}</strong>{" "}
+                                perderá el acceso al proyecto. Esta acción no se puede deshacer.
+                              </AlertDialogDescription>
+                            </AlertDialogHeader>
+                            <AlertDialogFooter>
+                              <AlertDialogCancel>Cancelar</AlertDialogCancel>
+                              <AlertDialogAction
+                                className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                                onClick={() => removeMember(m.id)}
+                              >
+                                Eliminar
+                              </AlertDialogAction>
+                            </AlertDialogFooter>
+                          </AlertDialogContent>
+                        </AlertDialog>
                       )}
-                    </Button>
-                  </div>
-                </>
+                    </div>
+                  ))}
+                </div>
               )}
             </CardContent>
           </Card>
 
-          {/* ── Invitaciones pendientes ── */}
-          {invitations.length > 0 && (
+          {/* Renombrar proyecto */}
+          {isOwner && (
+            <Card className="border-amber-400/40">
+              <CardHeader className="pb-3">
+                <div className="flex items-center gap-2">
+                  <IconPencil size={16} className="text-amber-500" />
+                  <span className="font-semibold text-sm text-amber-600 dark:text-amber-400">
+                    Renombrar proyecto
+                  </span>
+                </div>
+              </CardHeader>
+              <CardContent className="pt-0 flex flex-col gap-3">
+                <p className="text-xs text-muted-foreground">
+                  Cambia el nombre visible del proyecto para todos los miembros.
+                </p>
+                <div className="flex gap-2">
+                  <Input
+                    value={newName}
+                    onChange={(e) => setNewName(e.target.value)}
+                    onKeyDown={(e) => { if (e.key === "Enter") handleRename() }}
+                    placeholder="Nombre del proyecto"
+                    className="flex-1"
+                  />
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    className={`shrink-0 border-amber-400/60 hover:bg-amber-50 dark:hover:bg-amber-950/30 ${renamed ? "text-emerald-600 border-emerald-400/60" : "text-amber-600 dark:text-amber-400"}`}
+                    onClick={handleRename}
+                    disabled={renaming || !newName.trim() || newName.trim() === currentProject?.name}
+                  >
+                    {renamed ? (
+                      <><IconCheck size={14} /> Guardado</>
+                    ) : renaming ? "Guardando…" : "Renombrar"}
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+
+        {/* ── Col derecha: Invitar + Pendientes + Eliminar ── */}
+        <div className="flex flex-col gap-6">
+
+          {/* Invitar miembro */}
+          {isOwner && (
+            <Card>
+              <CardHeader className="pb-3">
+                <div className="flex items-center gap-2">
+                  <IconUserPlus size={16} className="text-muted-foreground" />
+                  <span className="font-semibold text-sm">Invitar miembro</span>
+                </div>
+              </CardHeader>
+              <CardContent className="pt-0 flex flex-col gap-3">
+                <div className="flex gap-2">
+                  <div className="flex-1">
+                    <Label htmlFor="invite-email" className="sr-only">
+                      Email del invitado
+                    </Label>
+                    <Input
+                      id="invite-email"
+                      type="email"
+                      placeholder="correo@ejemplo.com"
+                      value={email}
+                      onChange={(e) => setEmail(e.target.value)}
+                      onKeyDown={(e) => { if (e.key === "Enter") handleInvite() }}
+                    />
+                  </div>
+                  <Button onClick={handleInvite} disabled={inviting || !email.trim()}>
+                    {inviting ? "Enviando…" : "Invitar"}
+                  </Button>
+                </div>
+
+                {inviteLink && (
+                  <>
+                    <Separator />
+                    <div className="flex flex-col gap-2">
+                      <p className="text-xs text-muted-foreground flex items-center gap-1.5">
+                        <IconLink size={12} />
+                        Comparte este enlace con el invitado (válido 7 días)
+                      </p>
+                      <Button
+                        variant="outline"
+                        className="w-full gap-2 font-normal"
+                        onClick={() => handleCopy(inviteLink)}
+                      >
+                        {copiedToken === inviteLink ? (
+                          <>
+                            <IconCheck size={15} className="text-emerald-500 shrink-0" />
+                            <span className="text-emerald-600">¡Enlace copiado!</span>
+                          </>
+                        ) : (
+                          <>
+                            <IconCopy size={15} className="shrink-0" />
+                            <span className="truncate text-left">{inviteLink}</span>
+                          </>
+                        )}
+                      </Button>
+                    </div>
+                  </>
+                )}
+              </CardContent>
+            </Card>
+          )}
+
+          {/* Invitaciones pendientes */}
+          {isOwner && invitations.length > 0 && (
             <Card>
               <CardHeader className="pb-3">
                 <div className="flex items-center gap-2">
@@ -334,40 +396,41 @@ export function ProjectSettingsPage() {
               </CardContent>
             </Card>
           )}
-        </>
-      )}
 
-      {/* ── Zona de peligro (solo owner) ── */}
-      {isOwner && (
-        <Card className="border-destructive/40">
-          <CardHeader className="pb-3">
-            <div className="flex items-center gap-2">
-              <IconShieldX size={16} className="text-destructive" />
-              <span className="font-semibold text-sm text-destructive">Zona de peligro</span>
-            </div>
-          </CardHeader>
-          <CardContent className="pt-0">
-            <div className="flex items-center justify-between gap-4">
-              <div>
-                <p className="text-sm font-medium">Eliminar este proyecto</p>
-                <p className="text-xs text-muted-foreground mt-0.5">
-                  Se eliminarán todas las columnas, tareas, miembros e invitaciones. Esta acción es permanente.
-                </p>
-              </div>
-              <Button
-                variant="destructive"
-                size="sm"
-                className="shrink-0"
-                onClick={() => setDeleteDialogOpen(true)}
-              >
-                <IconTrash size={14} />
-                Eliminar
-              </Button>
-            </div>
-          </CardContent>
-        </Card>
-      )}
+          {/* Eliminar proyecto */}
+          {isOwner && (
+            <Card className="border-destructive/40">
+              <CardHeader className="pb-3">
+                <div className="flex items-center gap-2">
+                  <IconShieldX size={16} className="text-destructive" />
+                  <span className="font-semibold text-sm text-destructive">Zona de peligro</span>
+                </div>
+              </CardHeader>
+              <CardContent className="pt-0">
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <p className="text-sm font-medium">Eliminar este proyecto</p>
+                    <p className="text-xs text-muted-foreground mt-0.5">
+                      Se eliminarán todas las columnas, tareas, miembros e invitaciones. Esta acción es permanente.
+                    </p>
+                  </div>
+                  <Button
+                    variant="destructive"
+                    size="sm"
+                    className="shrink-0"
+                    onClick={() => setDeleteDialogOpen(true)}
+                  >
+                    <IconTrash size={14} />
+                    Eliminar
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+      </div>
 
+      {/* ── AlertDialog eliminar proyecto ── */}
       <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
         <AlertDialogContent>
           <AlertDialogHeader>

--- a/src/features/project/components/ProjectSettingsPage.tsx
+++ b/src/features/project/components/ProjectSettingsPage.tsx
@@ -126,7 +126,7 @@ export function ProjectSettingsPage() {
   }
 
   return (
-    <div className="p-6 flex flex-col gap-6 max-w-4xl w-full">
+    <div className="p-6 flex flex-col gap-6 max-w-4xl w-full mx-auto">
       {/* ── Header ── */}
       <div className="flex items-center gap-3 pb-2">
         <div className="p-2 rounded-lg bg-primary/10">
@@ -134,7 +134,7 @@ export function ProjectSettingsPage() {
         </div>
         <div>
           <h1 className="text-xl font-bold text-primary leading-tight">Ajustes del proyecto</h1>
-          <p className="text-sm text-muted-foreground">Gestiona los miembros y las invitaciones.</p>
+          <p className="text-sm text-muted-foreground">Gestiona los miembros, invitaciones y configuración general del proyecto.</p>
         </div>
       </div>
 

--- a/src/features/project/components/ProjectSettingsPage.tsx
+++ b/src/features/project/components/ProjectSettingsPage.tsx
@@ -126,7 +126,7 @@ export function ProjectSettingsPage() {
   }
 
   return (
-    <div className="p-6 flex flex-col gap-6 w-full">
+    <div className="p-6 flex flex-col gap-6 w-full min-h-full justify-center">
       {/* ── Header ── */}
       <div className="flex items-center gap-3 pb-2">
         <div className="p-2 rounded-lg bg-primary/10">

--- a/src/features/project/components/ProjectSettingsPage.tsx
+++ b/src/features/project/components/ProjectSettingsPage.tsx
@@ -126,7 +126,7 @@ export function ProjectSettingsPage() {
   }
 
   return (
-    <div className="p-6 flex flex-col gap-6 max-w-4xl w-full mx-auto">
+    <div className="p-6 flex flex-col gap-6 w-full">
       {/* ── Header ── */}
       <div className="flex items-center gap-3 pb-2">
         <div className="p-2 rounded-lg bg-primary/10">
@@ -139,7 +139,7 @@ export function ProjectSettingsPage() {
       </div>
 
       {/* ── Grid 2×2 ── */}
-      <div className="grid grid-cols-2 gap-6">
+      <div className="grid grid-cols-2 gap-6 max-w-4xl mx-auto w-full">
 
         {/* ── Col izquierda: Miembros + Renombrar ── */}
         <div className="flex flex-col gap-6">

--- a/src/features/project/components/ProjectSettingsPage.tsx
+++ b/src/features/project/components/ProjectSettingsPage.tsx
@@ -126,7 +126,7 @@ export function ProjectSettingsPage() {
   }
 
   return (
-    <div className="p-6 flex flex-col gap-6 w-full min-h-full justify-center">
+    <div className="p-6 flex flex-col gap-6 w-full min-h-[calc(100vh-4rem)] justify-center">
       {/* ── Header ── */}
       <div className="flex items-center gap-3 pb-2">
         <div className="p-2 rounded-lg bg-primary/10">

--- a/src/features/project/components/ProjectSettingsPage.tsx
+++ b/src/features/project/components/ProjectSettingsPage.tsx
@@ -126,7 +126,7 @@ export function ProjectSettingsPage() {
   }
 
   return (
-    <div className="p-6 flex flex-col gap-6 w-full min-h-[calc(100vh-4rem)] justify-center">
+    <div className="p-6 flex flex-col gap-6 w-full min-h-[calc(100vh-4rem)]">
       {/* ── Header ── */}
       <div className="flex items-center gap-3 pb-2">
         <div className="p-2 rounded-lg bg-primary/10">
@@ -139,6 +139,7 @@ export function ProjectSettingsPage() {
       </div>
 
       {/* ── Grid 2×2 ── */}
+      <div className="flex-1 flex items-center">
       <div className="grid grid-cols-2 gap-6 max-w-4xl mx-auto w-full">
 
         {/* ── Col izquierda: Miembros + Renombrar ── */}
@@ -429,6 +430,8 @@ export function ProjectSettingsPage() {
           )}
         </div>
       </div>
+
+      </div>{/* cierre flex-1 wrapper */}
 
       {/* ── AlertDialog eliminar proyecto ── */}
       <AlertDialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>

--- a/src/features/project/context/projectsCtx.ts
+++ b/src/features/project/context/projectsCtx.ts
@@ -8,6 +8,7 @@ export interface ProjectsContextValue {
   userRoles: Record<string, MemberRole>
   createProject: (values: ProjectFormValues) => Promise<Project | null>
   deleteProject: (id: string) => Promise<void>
+  renameProject: (id: string, name: string) => Promise<void>
 }
 
 export const ProjectsContext = createContext<ProjectsContextValue | null>(null)

--- a/src/features/project/hooks/useProjects.ts
+++ b/src/features/project/hooks/useProjects.ts
@@ -86,5 +86,10 @@ export const useProjects = () => {
     })
   }
 
-  return { projects, loading, createProject, deleteProject, userRoles }
+  const renameProject = async (id: string, name: string) => {
+    const { error } = await supabase.from("projects").update({ name }).eq("id", id)
+    if (!error) setProjects((prev) => prev.map((p) => (p.id === id ? { ...p, name } : p)))
+  }
+
+  return { projects, loading, createProject, deleteProject, renameProject, userRoles }
 }

--- a/src/features/task/components/taskChips.ts
+++ b/src/features/task/components/taskChips.ts
@@ -7,20 +7,20 @@ export const PRIORITY_CONFIG: Record<
   p0: {
     label: "P0",
     className: "bg-red-100 text-red-600",
-    borderClassName: "border-red-200 border-l-red-400",
-    bgClassName: "bg-red-50/60",
+    borderClassName: "border-red-200 border-l-red-400 dark:border-red-900 dark:border-l-red-600",
+    bgClassName: "bg-red-50/60 dark:bg-red-950/40",
   },
   p1: {
     label: "P1",
     className: "bg-orange-100 text-orange-600",
-    borderClassName: "border-orange-200 border-l-orange-400",
-    bgClassName: "bg-orange-50/60",
+    borderClassName: "border-orange-200 border-l-orange-400 dark:border-orange-900 dark:border-l-orange-600",
+    bgClassName: "bg-orange-50/60 dark:bg-orange-950/40",
   },
   p2: {
     label: "P2",
     className: "bg-blue-100 text-blue-600",
-    borderClassName: "border-blue-200 border-l-blue-400",
-    bgClassName: "bg-blue-50/50",
+    borderClassName: "border-blue-200 border-l-blue-400 dark:border-blue-900 dark:border-l-blue-600",
+    bgClassName: "bg-blue-50/50 dark:bg-blue-950/40",
   },
 }
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,9 +1,12 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
+import { ThemeProvider } from "@/shared/index";
 
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
   </StrictMode>
 );

--- a/src/shared/components/Header.tsx
+++ b/src/shared/components/Header.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { IconPlus } from "@tabler/icons-react";
+import { IconPlus, IconSun, IconMoon } from "@tabler/icons-react";
 import {
   Button,
   SearchInput,
@@ -8,6 +8,7 @@ import {
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
+  useTheme,
 } from "@/shared/index";
 import { useKanban } from "@/features/board/index";
 import { CreateColumnSheet } from "@/features/column/index";
@@ -20,6 +21,7 @@ interface HeaderProps {
 
 export function Header({ searchValue, onSearchChange, projectName }: HeaderProps) {
   const { createNewColumn, columns, tasks, userRole } = useKanban();
+  const { theme, toggleTheme } = useTheme();
   const [createColumnDialogOpen, setCreateColumnDialogOpen] =
     useState<boolean>(false);
 
@@ -45,39 +47,50 @@ export function Header({ searchValue, onSearchChange, projectName }: HeaderProps
             )}
           </h1>
         </div>
-        {onSearchChange && (
-          <div className="flex items-center gap-4">
-            <TooltipProvider>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <div>
-                    <SearchInput
-                      value={searchValue ?? ""}
-                      onChange={onSearchChange}
-                      disabled={tasks.length === 0}
-                    />
-                  </div>
-                </TooltipTrigger>
-                {tasks.length === 0 && (
-                  <TooltipContent>
-                    Crea una tarea para empezar a filtrar
-                  </TooltipContent>
-                )}
-              </Tooltip>
-            </TooltipProvider>
-            {isOwner && (
-              <Button
-                onClick={() => setCreateColumnDialogOpen(true)}
-                className="text-black group border-dashed border-2 hover:border-primary hover:bg-primary/5 hover:text-primary transition-all"
-                variant="outline"
-                disabled={columns.length >= 6}
-              >
-                <IconPlus className="h-4 w-4 mr-2 transition-transform duration-300 group-hover:rotate-90" />
-                Agregar Columna
-              </Button>
-            )}
-          </div>
-        )}
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={toggleTheme}
+            aria-label="Cambiar tema"
+            className="text-muted-foreground hover:text-foreground"
+          >
+            {theme === "dark" ? <IconSun size={18} /> : <IconMoon size={18} />}
+          </Button>
+          {onSearchChange && (
+            <>
+              <TooltipProvider>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <div>
+                      <SearchInput
+                        value={searchValue ?? ""}
+                        onChange={onSearchChange}
+                        disabled={tasks.length === 0}
+                      />
+                    </div>
+                  </TooltipTrigger>
+                  {tasks.length === 0 && (
+                    <TooltipContent>
+                      Crea una tarea para empezar a filtrar
+                    </TooltipContent>
+                  )}
+                </Tooltip>
+              </TooltipProvider>
+              {isOwner && (
+                <Button
+                  onClick={() => setCreateColumnDialogOpen(true)}
+                  className="text-black group border-dashed border-2 hover:border-primary hover:bg-primary/5 hover:text-primary transition-all"
+                  variant="outline"
+                  disabled={columns.length >= 6}
+                >
+                  <IconPlus className="h-4 w-4 mr-2 transition-transform duration-300 group-hover:rotate-90" />
+                  Agregar Columna
+                </Button>
+              )}
+            </>
+          )}
+        </div>
       </header>
       {onSearchChange && isOwner && (
         <CreateColumnSheet

--- a/src/shared/components/Header.tsx
+++ b/src/shared/components/Header.tsx
@@ -80,7 +80,7 @@ export function Header({ searchValue, onSearchChange, projectName }: HeaderProps
               {isOwner && (
                 <Button
                   onClick={() => setCreateColumnDialogOpen(true)}
-                  className="text-black group border-dashed border-2 hover:border-primary hover:bg-primary/5 hover:text-primary transition-all"
+                  className="group border-dashed border-2 hover:border-primary hover:bg-primary/5 hover:text-primary transition-all"
                   variant="outline"
                   disabled={columns.length >= 6}
                 >

--- a/src/shared/context/ThemeContext.tsx
+++ b/src/shared/context/ThemeContext.tsx
@@ -1,0 +1,33 @@
+import { createContext, useContext, useEffect, useState } from "react";
+
+type Theme = "light" | "dark";
+
+interface ThemeContextType {
+  theme: Theme;
+  toggleTheme: () => void;
+}
+
+const ThemeContext = createContext<ThemeContextType | null>(null);
+
+export function ThemeProvider({ children }: { children: React.ReactNode }) {
+  const [theme, setTheme] = useState<Theme>(() => {
+    const saved = localStorage.getItem("theme") as Theme | null;
+    if (saved) return saved;
+    return window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
+  });
+
+  useEffect(() => {
+    document.documentElement.classList.toggle("dark", theme === "dark");
+    localStorage.setItem("theme", theme);
+  }, [theme]);
+
+  const toggleTheme = () => setTheme((t) => (t === "dark" ? "light" : "dark"));
+
+  return <ThemeContext.Provider value={{ theme, toggleTheme }}>{children}</ThemeContext.Provider>;
+}
+
+export const useTheme = () => {
+  const ctx = useContext(ThemeContext);
+  if (!ctx) throw new Error("useTheme must be used within ThemeProvider");
+  return ctx;
+};

--- a/src/shared/index.ts
+++ b/src/shared/index.ts
@@ -18,5 +18,6 @@ export * from "./components/ui/skeleton";
 export * from "./components/ui/textarea";
 export * from "./components/ui/tooltip";
 export * from "./context/SearchContext";
+export * from "./context/ThemeContext";
 export * from "./hooks/use-mobile";
 export * from "./lib/utils";

--- a/tailwind.css
+++ b/tailwind.css
@@ -56,25 +56,27 @@ html, body, #root {
 }
 
 .dark {
-    --background: hsl(201.3 50% 10%);
-    --foreground: hsl(201.3 5% 98%);
-    --card: hsl(201.3 50% 10%);
-    --card-foreground: hsl(201.3 5% 98%);
-    --popover: hsl(201.3 50% 5%);
-    --popover-foreground: hsl(201.3 5% 98%);
-    --primary: hsl(201.3 96.3% 32.2%);
+    /* GitHub dark theme — Primer color system */
+    --background: hsl(216 28% 7%);        /* #0d1117 canvas.default */
+    --foreground: hsl(213 15% 83%);       /* #c9d1d9 fg.default */
+    --card: hsl(215 22% 11%);             /* #161b22 canvas.overlay */
+    --card-foreground: hsl(213 15% 83%);
+    --popover: hsl(215 22% 11%);          /* #161b22 */
+    --popover-foreground: hsl(213 15% 83%);
+    --primary: hsl(212 92% 57%);          /* #2f81f7 accent.fg */
     --primary-foreground: hsl(0 0% 100%);
-    --secondary: hsl(201.3 30% 20%);
-    --secondary-foreground: hsl(0 0% 100%);
-    --muted: hsl(163.3 30% 25%);
-    --muted-foreground: hsl(201.3 5% 65%);
-    --accent: hsl(163.3 30% 25%);
-    --accent-foreground: hsl(201.3 5% 95%);
-    --destructive: hsl(0 100% 50%);
-    --destructive-foreground: hsl(201.3 5% 98%);
-    --border: hsl(201.3 30% 50%);
-    --input: hsl(201.3 30% 50%);
-    --ring: hsl(201.3 96.3% 32.2%);
+    --secondary: hsl(215 14% 15%);        /* #21262d canvas.subtle */
+    --secondary-foreground: hsl(213 15% 83%);
+    --muted: hsl(215 14% 15%);            /* #21262d */
+    --muted-foreground: hsl(215 8% 57%);  /* #8b949e fg.muted */
+    --accent: hsl(215 14% 15%);           /* #21262d */
+    --accent-foreground: hsl(213 15% 83%);
+    --destructive: hsl(2 92% 63%);        /* #f85149 danger.fg */
+    --destructive-foreground: hsl(0 0% 100%);
+    --border: hsl(216 12% 21%);           /* #30363d border.default */
+    --input: hsl(216 12% 21%);            /* #30363d */
+    --ring: hsl(212 92% 57%);             /* #2f81f7 */
+    --row-selected: hsl(212 92% 15%);
     --radius: 0.5rem;
 }
 


### PR DESCRIPTION
## 📌 Descripción

En este pr se añade soporte de tema claro/oscuro con paleta GitHub Primer y persistencia en `localStorage`. También amplía la página de Ajustes con un grid 2×2 que incluye renombrar y eliminar el proyecto con confirmación.

---

## 🔗 Issue relacionado

Closes #59 

---

## 🧪 Tipo de cambio

Marca lo que aplique:

- [x] ✨ New feature
- [x] 🐛 Bug fix
- [x] 🎨 Style / UI
- [ ] 📚 Documentation
- [ ] 🔧 Chore / Refactor

---

## ✅ Checklist

- [x] El código compila y funciona correctamente
- [x] He probado los cambios manualmente
- [x] No rompe funcionalidad existente
- [x] El código sigue las convenciones del proyecto
- [ ] He actualizado la documentación si aplica
