### PR TITLE
[FEATURE] Integrar tests de Vitest en CI y pre-commit

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,160 @@
+name: Tests
+
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vite.config.ts'
+      - '.github/workflows/tests.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'src/**'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'vite.config.ts'
+      - '.github/workflows/tests.yml'
+
+jobs:
+  tests:
+    name: Run Tests
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        id: tests
+        continue-on-error: true
+        run: npm run test:run
+
+      - name: Mark PR as tests passed
+        if: github.event_name == 'pull_request' && steps.tests.outcome == 'success'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const passedLabel = {
+              name: 'test passed',
+              color: '0e8a16',
+              description: 'Tests passed in CI',
+            };
+            const failedLabel = {
+              name: 'test failed',
+              color: 'd73a4a',
+              description: 'Tests failed in CI',
+            };
+            const issue_number = context.payload.pull_request.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const marker = '<!-- tests-status -->';
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            async function ensureLabel(label) {
+              try {
+                await github.rest.issues.createLabel({ owner, repo, ...label });
+              } catch (error) {
+                if (error.status !== 422) throw error;
+              }
+            }
+
+            async function removeLabel(name) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+            }
+
+            async function upsertComment(body) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number, per_page: 100,
+              });
+              const existing = comments.find((c) => c.body && c.body.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+                return;
+              }
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+            await ensureLabel(passedLabel);
+            await ensureLabel(failedLabel);
+            await removeLabel(failedLabel.name);
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [passedLabel.name] });
+            await upsertComment(`${marker}\nTests passed in CI.\n\nRun details: ${runUrl}`);
+
+      - name: Mark PR as tests failed
+        if: github.event_name == 'pull_request' && steps.tests.outcome == 'failure'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const passedLabel = {
+              name: 'test passed',
+              color: '0e8a16',
+              description: 'Tests passed in CI',
+            };
+            const failedLabel = {
+              name: 'test failed',
+              color: 'd73a4a',
+              description: 'Tests failed in CI',
+            };
+            const issue_number = context.payload.pull_request.number;
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const marker = '<!-- tests-status -->';
+            const runUrl = `${context.serverUrl}/${owner}/${repo}/actions/runs/${context.runId}`;
+
+            async function ensureLabel(label) {
+              try {
+                await github.rest.issues.createLabel({ owner, repo, ...label });
+              } catch (error) {
+                if (error.status !== 422) throw error;
+              }
+            }
+
+            async function removeLabel(name) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name });
+              } catch (error) {
+                if (error.status !== 404) throw error;
+              }
+            }
+
+            async function upsertComment(body) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner, repo, issue_number, per_page: 100,
+              });
+              const existing = comments.find((c) => c.body && c.body.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({ owner, repo, comment_id: existing.id, body });
+                return;
+              }
+              await github.rest.issues.createComment({ owner, repo, issue_number, body });
+            }
+
+            await ensureLabel(passedLabel);
+            await ensureLabel(failedLabel);
+            await removeLabel(passedLabel.name);
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [failedLabel.name] });
+            await upsertComment(`${marker}\nTests failed in CI.\n\nRun details: ${runUrl}`);
+
+      - name: Fail workflow if tests failed
+        if: steps.tests.outcome == 'failure'
+        run: exit 1

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
 npx lint-staged
+npm run test:run

--- a/src/features/auth/__tests__/AuthGuard.test.tsx
+++ b/src/features/auth/__tests__/AuthGuard.test.tsx
@@ -3,7 +3,7 @@ import { MemoryRouter, Route, Routes } from "react-router"
 import { describe, expect, it, vi } from "vitest"
 import { AuthGuard } from "../components/AuthGuard"
 
-vi.mock("../context/AuthContext", () => ({
+vi.mock("../context/useAuth", () => ({
   useAuth: () => ({ user: null, loading: false }),
 }))
 

--- a/src/features/project/__tests__/useProjects.test.ts
+++ b/src/features/project/__tests__/useProjects.test.ts
@@ -8,17 +8,27 @@ vi.mock("@/features/auth", () => ({
   useAuth: () => ({ user: mockUser }),
 }))
 
-const mockSelect = vi.fn()
-const mockInsert = vi.fn()
-const mockDelete = vi.fn()
+const mockProjectMembers = {
+  select: vi.fn(),
+  insert: vi.fn(),
+}
+const mockProjects = {
+  select: vi.fn(),
+  insert: vi.fn(),
+  delete: vi.fn(),
+}
+const mockColumns = {
+  insert: vi.fn(),
+}
 
 vi.mock("@/shared/supabase", () => ({
   supabase: {
-    from: vi.fn(() => ({
-      select: mockSelect,
-      insert: mockInsert,
-      delete: mockDelete,
-    })),
+    from: vi.fn((table: string) => {
+      if (table === "project_members") return mockProjectMembers
+      if (table === "projects") return mockProjects
+      if (table === "columns") return mockColumns
+      return {}
+    }),
   },
 }))
 
@@ -28,6 +38,7 @@ describe("useProjects", () => {
   })
 
   it("carga proyectos al montar", async () => {
+    const memberRows = [{ project_id: "p1", role: "owner" }]
     const projects = [
       {
         id: "p1",
@@ -37,8 +48,14 @@ describe("useProjects", () => {
         created_at: new Date().toISOString(),
       },
     ]
-    mockSelect.mockReturnValue({
-      order: vi.fn().mockResolvedValue({ data: projects }),
+
+    mockProjectMembers.select.mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ data: memberRows }),
+    })
+    mockProjects.select.mockReturnValue({
+      in: vi.fn().mockReturnValue({
+        order: vi.fn().mockResolvedValue({ data: projects }),
+      }),
     })
 
     const { result } = renderHook(() => useProjects())
@@ -53,6 +70,7 @@ describe("useProjects", () => {
   })
 
   it("createProject agrega el proyecto a la lista", async () => {
+    const memberRows = [{ project_id: "p1", role: "owner" }]
     const existing = [
       {
         id: "p1",
@@ -70,14 +88,21 @@ describe("useProjects", () => {
       created_at: new Date().toISOString(),
     }
 
-    mockSelect.mockReturnValue({
-      order: vi.fn().mockResolvedValue({ data: existing }),
+    mockProjectMembers.select.mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ data: memberRows }),
     })
-    mockInsert.mockReturnValue({
+    mockProjectMembers.insert.mockResolvedValue({ data: null, error: null })
+    mockProjects.select.mockReturnValue({
+      in: vi.fn().mockReturnValue({
+        order: vi.fn().mockResolvedValue({ data: existing }),
+      }),
+    })
+    mockProjects.insert.mockReturnValue({
       select: vi.fn().mockReturnValue({
         single: vi.fn().mockResolvedValue({ data: newProject, error: null }),
       }),
     })
+    mockColumns.insert.mockResolvedValue({ data: null, error: null })
 
     const { result } = renderHook(() => useProjects())
     await waitFor(() => expect(result.current.loading).toBe(false))
@@ -91,6 +116,10 @@ describe("useProjects", () => {
   })
 
   it("deleteProject elimina el proyecto de la lista", async () => {
+    const memberRows = [
+      { project_id: "p1", role: "owner" },
+      { project_id: "p2", role: "owner" },
+    ]
     const projects = [
       {
         id: "p1",
@@ -107,10 +136,16 @@ describe("useProjects", () => {
         created_at: new Date().toISOString(),
       },
     ]
-    mockSelect.mockReturnValue({
-      order: vi.fn().mockResolvedValue({ data: projects }),
+
+    mockProjectMembers.select.mockReturnValue({
+      eq: vi.fn().mockResolvedValue({ data: memberRows }),
     })
-    mockDelete.mockReturnValue({
+    mockProjects.select.mockReturnValue({
+      in: vi.fn().mockReturnValue({
+        order: vi.fn().mockResolvedValue({ data: projects }),
+      }),
+    })
+    mockProjects.delete.mockReturnValue({
       eq: vi.fn().mockResolvedValue({ error: null }),
     })
 


### PR DESCRIPTION
## 📌 Descripción

En este pr se añade ejecución automática de los tests de Vitest en dos momentos: antes de cada commit via husky, y en cada PR via GitHub Actions con feedback visual mediante labels y comentarios.

---

## 🔗 Issue relacionado

Closes #67

---

## 🧪 Tipo de cambio

- [x] ✨ New feature
- [x] 🔧 Chore / Refactor

---

## ✅ Checklist

- [x] El código compila y funciona correctamente
- [x] He probado los cambios manualmente
- [x] No rompe funcionalidad existente
- [x] El código sigue las convenciones del proyecto
- [ ] He actualizado la documentación si aplica
